### PR TITLE
Specify master as default install candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You need both this plugin and ESLint installed.
 
 ```bash
 yarn add eslint@6.8.0
-yarn add ssh://git@github.com:einride/eslint-plugin.git#5f56a246667abdea3ea26169ed8a97a67a66a784
+yarn add ssh://git@github.com:einride/eslint-plugin.git#master
 ```
 
 ## Usage


### PR DESCRIPTION
`master` will be implicit "latest". 

`yarn.lock` will prevent implicit version drifting. 

If a project wants to hold to a specific version, they should lock to that with `#vX.X.X`.