### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Einride's ESLint configuration as a sharable plugin",
   "author": "Pontus Persson",
   "main": "lib/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "4.8.0",
     "@typescript-eslint/parser": "4.8.0",


### PR DESCRIPTION
- Switch back from "config" to "plugin" for reasons explained in #20 
- The version number in package.json will be updated before publishing to npm, but it won't be reflected in package.json. Setting the version number to "0.0.0-development" is convention when using semantic release, to signal it's not to be touched:
https://semantic-release.gitbook.io/semantic-release/support/faq\#why-is-the-package-jsons-version-not-updated-in-my-repository
- Add public access flag that is needed for scoped packages that are intended to be public: https://docs.npmjs.com/cli/v7/using-npm/config#access