### PR TITLE
feat: disable react/require-default-props

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -62,6 +62,7 @@ module.exports = {
         "react/jsx-wrap-multilines": 0,
         "react/no-array-index-key": 0,
         "react/prop-types": 0,
+        "react/require-default-props": 0,
       },
       settings: {
         "import/parsers": {


### PR DESCRIPTION
Since we are not using prop-types, default props should not be required.