### PR TITLE
chore: extend prettier instead of prettier/@typescript-eslint

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ module.exports = {
         "airbnb",
         "airbnb/hooks",
         "plugin:@typescript-eslint/recommended",
-        "prettier/@typescript-eslint",
+        "prettier",
         "plugin:prettier/recommended",
       ],
       rules: {


### PR DESCRIPTION
Since eslint-config-prettier/@typescript-eslint has been merged into eslint-config-prettier.