### PR TITLE
feat: enable explicit-function-return-type rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,12 @@ module.exports = {
           "error",
           { extensions: [".js", ".jsx", ".tsx"] },
         ],
+        "@typescript-eslint/explicit-function-return-type": [
+          "error",
+          {
+            allowExpressions: true,
+          },
+        ],
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "@typescript-eslint/no-explicit-any": "error",
         "@typescript-eslint/no-unused-vars": "error",


### PR DESCRIPTION
BREAKING CHANGE: Functions return types will have to be set explicitly.
