### PR TITLE
feat: set deprecation to warn instead of error

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ module.exports = {
             unnamedComponents: "arrow-function",
           },
         ],
-        "deprecation/deprecation": "error",
+        "deprecation/deprecation": "warn",
       },
       settings: {
         "import/parsers": {


### PR DESCRIPTION
We're generally avoiding using `warn`, since it enables piling warnings that are not required to do anything about. I think that the deprecation rule might be a good exception, since we don't want to break CI when something in use is deprecated.