### PR TITLE
fix: allow node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "author": "Filip Tammergård",
   "license": "MIT",
   "engines": {
-    "node": "14 || 16"
+    "node": "14 || 16 || 18"
   },
   "bugs": {
     "email": "open-source@einride.tech",


### PR DESCRIPTION
Evolve needs it to solve CI problems related to commit-lint.
