### PR TITLE
Version 7

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,12 +199,6 @@ module.exports = {
           },
         ],
 
-        // Enabled by `eslint-config-airbnb`: https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb/rules/react.js#L220-L226
-        // Disabled because we're using TypeScript
-        // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prop-types.md
-        // TODO: Enable since it supports prop validation with TypeScript?
-        "react/prop-types": "off",
-
         // Enabled by `eslint-config-airbnb`: https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb/rules/react.js#L390-L394
         // Disabled because we're using TypeScript
         // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/require-default-props.md

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ module.exports = {
         // TODO: Enable?
         "import/no-unresolved": "off",
 
-        // Enforce consistent ordering of imports
+        // Enforce consistent ordering of imports. Used in conjunction with `sort-imports`.
         // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md
         "import/order": [
           "error",
@@ -210,6 +210,16 @@ module.exports = {
         // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/require-default-props.md
         // TODO: Enable since it supports prop validation with TypeScript?
         "react/require-default-props": "off",
+
+        // Enforce consistent ordering of import members. Used in conjunction with `import/order`.
+        // https://eslint.org/docs/latest/rules/sort-imports
+        "sort-imports": [
+          "error",
+          {
+            // Ignore sorting of import declarations that are already handled by `import/order`: https://eslint.org/docs/latest/rules/sort-imports#ignoredeclarationsort
+            ignoreDeclarationSort: true,
+          },
+        ],
       },
       overrides: [
         // Allow default exports in config files that require them

--- a/index.js
+++ b/index.js
@@ -174,8 +174,7 @@ module.exports = {
           "error",
           {
             // Allow JSX in these file types
-            // TODO: Remove .js (and .jsx)?
-            extensions: [".js", ".jsx", ".tsx"],
+            extensions: [".tsx"],
           },
         ],
 

--- a/index.js
+++ b/index.js
@@ -92,9 +92,8 @@ module.exports = {
         ],
 
         // Enabled by `eslint-config-airbnb`: https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/imports.js#L35-L37
-        // Disabled to avoid false positive reports of missing dependencies
+        // Disabled since we're not using Node or Webpack as module bundler
         // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-unresolved.md
-        // TODO: Enable?
         "import/no-unresolved": "off",
 
         // Enforce consistent ordering of imports. Used in conjunction with `sort-imports`.
@@ -199,9 +198,8 @@ module.exports = {
         ],
 
         // Enabled by `eslint-config-airbnb`: https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb/rules/react.js#L390-L394
-        // Disabled because we're using TypeScript
+        // Disabled because we're using TypeScript and don't want to enforce default props
         // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/require-default-props.md
-        // TODO: Enable since it supports prop validation with TypeScript?
         "react/require-default-props": "off",
 
         // Enforce consistent ordering of import members. Used in conjunction with `import/order`.


### PR DESCRIPTION
- feat!: enforce consistent ordering of import members
- feat: enable prop-types rule since it supports typescript
- feat!: only allow JSX in .tsx files
- chore: remove legay todos
