### PR TITLE
chore: update recommended node version to 22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Review
         run: yarn review

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Review
         run: yarn review

--- a/package.json
+++ b/package.json
@@ -60,5 +60,8 @@
   "publishConfig": {
     "access": "public",
     "provenance": true
+  },
+  "engines": {
+    "node": ">=22"
   }
 }


### PR DESCRIPTION
Since node v22 will become LTS in next week, we can safely recommend v22 for this repo. Setting engine configuration is just a recommendation so updating here for documentation purpose.
https://nodejs.org/en/about/previous-releases